### PR TITLE
add some starter code

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1175,6 +1175,7 @@ dependencies = [
  "async-tiff",
  "extendr-api",
  "object_store",
+ "tokio",
 ]
 
 [[package]]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -11,3 +11,4 @@ name = 'rustycogs'
 extendr-api = '*'
 async-tiff = '*'
 object_store = "0.12"
+tokio = { version = "1.43", features = ["rt-multi-thread"] }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -1,28 +1,53 @@
+use async_tiff::{decoder::DecoderRegistry, TIFF};
 use extendr_api::prelude::*;
-use async_tiff::TIFF;
 //use async_tiff::decoder::DecoderRegistry;
-use async_tiff::reader::ObjectReader;
+use async_tiff::reader::{AsyncFileReader, ObjectReader};
+use tokio::runtime::{Builder, Runtime};
 
 //use std::io::BufReader;
-use std::sync::Arc;
+use std::{
+    cell::OnceCell,
+    sync::{Arc, OnceLock},
+};
 //use super::*;
 use object_store::local::LocalFileSystem;
 //use tiff::decoder::{DecodingResult, Limits};
 
+static TOKIO_RUNTIME: OnceLock<Runtime> = OnceLock::new();
+
+// Helper function to get a tokio runtime
+fn get_rt() -> &'static Runtime {
+    TOKIO_RUNTIME.get_or_init(|| {
+        Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create tokio runtime")
+    })
+}
 
 /// Return string `"Hello world!"` to R.
 /// @export
 #[extendr]
-fn rusty(file: String) -> &'static str {
-        let dir = "/tiff/";
-        let path = object_store::path::Path::parse(file).unwrap();
-        let store = Arc::new(LocalFileSystem::new_with_prefix(dir).unwrap());
-        let reader = Arc::new(ObjectReader::new(store, path));
+fn rusty(file: String) -> Raw {
+    let dir = "/tiff/";
+    let path = object_store::path::Path::parse(file).unwrap();
+    let store = Arc::new(LocalFileSystem::new_with_prefix(dir).unwrap());
+    let reader = Arc::new(ObjectReader::new(store, path));
+    let rt = get_rt();
 
-        // we can't .await.unwrap MDS
-        //let cog_reader = TIFF::try_open(reader.clone()).await.unwrap();
-
-    dir
+    let cog_reader = rt.block_on(async {
+        TIFF::try_open(Box::new(reader.as_ref().clone()))
+            .await
+            .unwrap()
+    });
+    let ifds = cog_reader.ifds().as_ref();
+    let ifd = &ifds[0];
+    let decoder_registry = DecoderRegistry::default();
+    let tile = rt
+        .block_on(ifd.fetch_tile(0, 0, reader.as_ref()))
+        .expect("failed to get tile");
+    let tile = tile.decode(&decoder_registry).expect("Failed to decode");
+    Raw::from_bytes(&tile)
 }
 
 // example code from async-tiff
@@ -35,7 +60,7 @@ fn rusty(file: String) -> &'static str {
 //        let decoder_registry = DecoderRegistry::default();
 //        let tile = ifd.fetch_tile(0, 0, reader.as_ref()).await.unwrap();
 //        let tile = tile.decode(&decoder_registry).unwrap();
-        //std::fs::write("img.buf", tile).unwrap();
+//std::fs::write("img.buf", tile).unwrap();
 
 // Macro to generate exports.
 // This ensures exported functions are registered with R.


### PR DESCRIPTION
This PR adds some starter code to help worth with async code inside of an extendr package this is using tokio as the multithreaded run time. It is a similar approach as used by the python library. 

We put it inside of a `OnceLock<>` which allows us to create a global object that can be initialized only once. Then we have a helper function to fetch that static tokio runtime. Any async code we need to run can go inside of it with `rt.block_on()` this will await the async code for us.